### PR TITLE
it's just an example of using s3 [for your reference]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,9 @@ FLYWAY_ENABLED=true
 ECR_IMAGE_URI=
 AWS_ACCOUNT_ID=
 AWS_REGION=
+
+# AWS S3 Configuration
+AWS_ACCESS_KEY_ID=your-access-key-id
+AWS_SECRET_ACCESS_KEY=your-secret-access-key
+AWS_S3_BUCKET_NAME=your-bucket-name
+AWS_S3_REGION=us-east-1

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,13 @@
 			<artifactId>spring-boot-starter-thymeleaf</artifactId>
 		</dependency>
 
+		<!-- AWS S3 SDK -->
+		<dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>s3</artifactId>
+			<version>2.29.33</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/workflow/common/exception/handler/ValidationExceptionHandler.java
+++ b/src/main/java/com/workflow/common/exception/handler/ValidationExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.Map;
@@ -66,5 +67,25 @@ public class ValidationExceptionHandler {
                 ex.getMessage() != null ? ex.getMessage() : "Invalid request parameters",
                 request
         );
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceeded(
+            MaxUploadSizeExceededException ex,
+            HttpServletRequest request) {
+
+        long maxSize = ex.getMaxUploadSize();
+        String maxSizeStr = maxSize > 0 ? formatFileSize(maxSize) : "10MB";
+
+        return ResponseBuilder.buildBadRequestResponse(
+                "File size exceeds the maximum allowed limit of " + maxSizeStr + ". Please upload a smaller file.",
+                request
+        );
+    }
+
+    private String formatFileSize(long bytes) {
+        if (bytes < 1024) return bytes + " bytes";
+        if (bytes < 1024 * 1024) return (bytes / 1024) + " KB";
+        return (bytes / (1024 * 1024)) + " MB";
     }
 }

--- a/src/main/java/com/workflow/config/AwsS3Config.java
+++ b/src/main/java/com/workflow/config/AwsS3Config.java
@@ -1,0 +1,51 @@
+package com.workflow.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${aws.s3.region:us-east-1}")
+    private String region;
+
+    @Value("${aws.accessKeyId:}")
+    private String accessKeyId;
+
+    @Value("${aws.secretAccessKey:}")
+    private String secretAccessKey;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(getCredentialsProvider())
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(getCredentialsProvider())
+                .build();
+    }
+
+    private AwsCredentialsProvider getCredentialsProvider() {
+        if (accessKeyId != null && !accessKeyId.isEmpty()
+            && secretAccessKey != null && !secretAccessKey.isEmpty()) {
+            return StaticCredentialsProvider.create(
+                    AwsBasicCredentials.create(accessKeyId, secretAccessKey)
+            );
+        }
+        return DefaultCredentialsProvider.create();
+    }
+}

--- a/src/main/java/com/workflow/config/auth/SecurityConfig.java
+++ b/src/main/java/com/workflow/config/auth/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
             "/api/v1/auth/forgot-password",
             "/api/v1/auth/reset-password",
             "/api/v1/workers/invites/check/**",
+            "/api/v1/files/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs/**",
@@ -91,6 +92,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/clients/**").hasRole(COMPANY)
                         .requestMatchers("/api/v1/jobs/**").hasRole(COMPANY)
                         .requestMatchers("/api/v1/job-templates/**").hasRole(COMPANY)
+                        .requestMatchers("/api/v1/assets/**").hasRole(COMPANY)
                         .anyRequest().authenticated())
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))

--- a/src/main/java/com/workflow/controller/file/FileController.java
+++ b/src/main/java/com/workflow/controller/file/FileController.java
@@ -1,0 +1,88 @@
+package com.workflow.controller.file;
+
+import com.workflow.service.storage.FileStorageService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/files")
+@RequiredArgsConstructor
+public class FileController {
+
+    private final FileStorageService fileStorageService;
+
+    @Operation(summary = "Upload an image file", description = "Upload an image file to S3 storage. Supports JPEG, PNG, GIF, and WebP formats. Maximum file size: 10MB")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "File uploaded successfully"),
+        @ApiResponse(responseCode = "400", description = "Invalid file or file type"),
+        @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
+    @PostMapping(value = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Map<String, String>> uploadFile(
+            @Parameter(description = "Image file to upload", required = true)
+            @RequestParam("file") MultipartFile file) {
+
+        try {
+            if (file.isEmpty()) {
+                return ResponseEntity.badRequest()
+                        .body(Map.of("error", "File is empty"));
+            }
+
+            String contentType = file.getContentType();
+            if (contentType == null || !isValidImageType(contentType)) {
+                return ResponseEntity.badRequest()
+                        .body(Map.of("error", "Only image files are allowed (JPEG, PNG, GIF, WebP)"));
+            }
+
+            long maxFileSize = 10 * 1024 * 1024;
+            if (file.getSize() > maxFileSize) {
+                return ResponseEntity.badRequest()
+                        .body(Map.of("error", "File size exceeds maximum limit of 10MB"));
+            }
+
+            log.info("Uploading file: name={}, size={}, type={}",
+                     file.getOriginalFilename(), file.getSize(), file.getContentType());
+
+            String fileKey = fileStorageService.uploadFile(file);
+            String presignedUrl = fileStorageService.generatePresignedUrl(fileKey, Duration.ofHours(1));
+
+            Map<String, String> response = new HashMap<>();
+            response.put("message", "File uploaded successfully");
+            response.put("fileKey", fileKey);
+            response.put("url", presignedUrl);
+            response.put("originalFileName", file.getOriginalFilename());
+            response.put("fileSize", String.valueOf(file.getSize()));
+            response.put("contentType", file.getContentType());
+
+            return ResponseEntity.status(HttpStatus.CREATED).body(response);
+
+        } catch (Exception e) {
+            log.error("Error uploading file", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Failed to upload file: " + e.getMessage()));
+        }
+    }
+
+    private boolean isValidImageType(String contentType) {
+        return contentType.equals("image/jpeg") ||
+               contentType.equals("image/png") ||
+               contentType.equals("image/gif") ||
+               contentType.equals("image/webp");
+    }
+}

--- a/src/main/java/com/workflow/service/storage/FileStorageService.java
+++ b/src/main/java/com/workflow/service/storage/FileStorageService.java
@@ -1,0 +1,81 @@
+package com.workflow.service.storage;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileStorageService {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    public String uploadFile(MultipartFile file) throws IOException {
+        String fileName = generateFileName(file.getOriginalFilename());
+
+        log.info("Uploading file to S3: bucket={}, key={}, size={}",
+                 bucketName, fileName, file.getSize());
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileName)
+                .contentType(file.getContentType())
+                .build();
+
+        PutObjectResponse response = s3Client.putObject(
+                putObjectRequest,
+                RequestBody.fromInputStream(file.getInputStream(), file.getSize())
+        );
+
+        log.info("File uploaded successfully: key={}, etag={}", fileName, response.eTag());
+        return fileName;
+    }
+
+    public String generatePresignedUrl(String fileKey, Duration duration) {
+        log.info("Generating presigned URL: bucket={}, key={}, duration={}",
+                 bucketName, fileKey, duration);
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucketName)
+                .key(fileKey)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(duration)
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(presignRequest);
+        String url = presignedRequest.url().toString();
+
+        log.info("Presigned URL generated successfully for key={}", fileKey);
+        return url;
+    }
+
+    private String generateFileName(String originalFilename) {
+        String extension = "";
+        if (originalFilename != null && originalFilename.contains(".")) {
+            extension = originalFilename.substring(originalFilename.lastIndexOf("."));
+        }
+        return UUID.randomUUID().toString() + extension;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,11 @@ spring:
       mail.smtp.connectiontimeout: 5000
       mail.smtp.timeout: 5000
       mail.smtp.writetimeout: 5000
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+      enabled: true
 
 springdoc:
   swagger-ui:
@@ -68,6 +73,13 @@ worker-invitation:
   token:
     expiration-days: 7
   frontend-url: ${WORKER_INVITATION_FRONTEND_URL:http://localhost:3000}
+
+aws:
+  accessKeyId: ${AWS_ACCESS_KEY_ID:}
+  secretAccessKey: ${AWS_SECRET_ACCESS_KEY:}
+  s3:
+    bucket-name: ${AWS_S3_BUCKET_NAME:}
+    region: ${AWS_S3_REGION:}
 
 
 


### PR DESCRIPTION
 Features done in this MR:

  - Single image upload to S3
  - File type validation (JPEG, PNG, GIF, WebP)
  -  File size validation (max 10MB)
  -  Presigned URL generation (1 hour expiry)
  -  No authentication here 
  -  Proper error handling
  -  Swagger UI integration
  -  Works on both local (access keys) and EC2 (IAM role)
  
  
  
  But we need:
  - auth for uploading 
  - now works only with images, needs docs upload support (pdfs)
  - A Presigned URL is a temporary, secure URL that gives someone access to download a file from S3 without needing AWS  credentials.
 So When a user uploads an image, this code:
  1. Uploads the file to S3 (private bucket)
  2. Generates a presigned URL valid for 1 hour
  3. Returns the URL to the user
  
  So we need a way to have the access for the images using filekey or other methods(need checking online)

