### PR TITLE
feat(jobs): expose estimateId and estimateTotalNet in job response

### DIFF
--- a/src/main/java/com/workflow/dto/job/JobResponse.java
+++ b/src/main/java/com/workflow/dto/job/JobResponse.java
@@ -3,6 +3,7 @@ package com.workflow.dto.job;
 import com.workflow.common.constant.job.JobStatus;
 
 import lombok.*;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -32,4 +33,6 @@ public class JobResponse {
     private Map<Long, FieldValueResponse> fieldValues;
     private List<Long> assetIds;
     private AddressResponse address;
+    private Long estimateId;
+    private BigDecimal estimateTotalNet;
 }

--- a/src/main/java/com/workflow/repository/financial/EstimateRepository.java
+++ b/src/main/java/com/workflow/repository/financial/EstimateRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface EstimateRepository extends JpaRepository<Estimate, Long> {
@@ -30,6 +31,9 @@ public interface EstimateRepository extends JpaRepository<Estimate, Long> {
            "LEFT JOIN FETCH e.lineItems " +
            "WHERE e.id = :id AND e.company.id = :companyId")
     Optional<Estimate> findByIdWithDetailsAndCompanyId(@Param("id") Long id, @Param("companyId") Long companyId);
+
+    @Query("SELECT e.job.id, e.id, COALESCE(SUM(li.netAmount), 0) FROM Estimate e LEFT JOIN e.lineItems li WHERE e.job.id IN :jobIds GROUP BY e.job.id, e.id")
+    List<Object[]> findEstimateSummaryByJobIds(@Param("jobIds") List<Long> jobIds);
 
     boolean existsByJobId(Long jobId);
 

--- a/src/main/java/com/workflow/service/job/JobService.java
+++ b/src/main/java/com/workflow/service/job/JobService.java
@@ -1,5 +1,6 @@
 package com.workflow.service.job;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -90,6 +91,8 @@ public class JobService implements IJobService {
         private final IJobWorkflowService jobWorkflowService;
         private final AddressRepository addressRepository;
         private final CompanyCounterService companyCounterService;
+
+        private record EstimateSummary(Long estimateId, BigDecimal totalNet) {}
 
         @Override
         public JobResponse createJob(JobCreateRequest request, Long companyId) {
@@ -372,12 +375,21 @@ public class JobService implements IJobService {
                         }
                 }
 
+                // Batch-load estimate id + totalNet per job
+                Map<Long, EstimateSummary> estimateByJob = estimateRepository
+                                .findEstimateSummaryByJobIds(jobIds).stream()
+                                .collect(Collectors.toMap(
+                                                row -> (Long) row[0],
+                                                row -> new EstimateSummary((Long) row[1], (BigDecimal) row[2]),
+                                                (a, b) -> a));
+
                 return jobs.stream()
                                 .map(job -> mapToResponse(
                                                 job,
                                                 fieldValuesByJob.getOrDefault(job.getId(), new HashMap<>()),
                                                 assetIdsByJob.getOrDefault(job.getId(), new ArrayList<>()),
-                                                workerIdsByJob.getOrDefault(job.getId(), new ArrayList<>())))
+                                                workerIdsByJob.getOrDefault(job.getId(), new ArrayList<>()),
+                                                estimateByJob.get(job.getId())))
                                 .collect(Collectors.toList());
         }
 
@@ -623,11 +635,14 @@ public class JobService implements IJobService {
                         workerIds.addAll(uniqueWorkerIds);
                 });
 
-                return mapToResponse(job, values, assetIds, workerIds);
+                List<Object[]> rows = estimateRepository.findEstimateSummaryByJobIds(List.of(job.getId()));
+                EstimateSummary es = rows.isEmpty() ? null : new EstimateSummary((Long) rows.get(0)[1], (BigDecimal) rows.get(0)[2]);
+
+                return mapToResponse(job, values, assetIds, workerIds, es);
         }
 
         private JobResponse mapToResponse(Job job, Map<Long, FieldValueResponse> values, List<Long> assetIds,
-                        List<Long> workerIds) {
+                        List<Long> workerIds, EstimateSummary estimate) {
                 AddressResponse addressResponse = null;
 
                 if (job.getAddress() != null) {
@@ -661,6 +676,8 @@ public class JobService implements IJobService {
                                 .assetIds(assetIds)
                                 .assignedWorkerIds(workerIds) // <--- Added the union back here
                                 .address(addressResponse)
+                                .estimateId(estimate != null ? estimate.estimateId() : null)
+                                .estimateTotalNet(estimate != null ? estimate.totalNet() : null)
                                 .build();
         }
 


### PR DESCRIPTION
Add batch JPQL query to fetch estimate id and net total per job in one round-trip, avoiding N+1 on the jobs list endpoint.