### PR TITLE
fix(worker): reactivate archived worker instead of blocking re-invite

### DIFF
--- a/src/main/java/com/workflow/repository/worker/WorkerRepository.java
+++ b/src/main/java/com/workflow/repository/worker/WorkerRepository.java
@@ -37,5 +37,8 @@ public interface WorkerRepository extends JpaRepository<Worker, Long> {
 
     boolean existsByEmailIgnoreCaseAndArchivedFalse(String email);
 
+    @Query("SELECT w FROM Worker w JOIN FETCH w.user WHERE w.company.id = :companyId AND w.user.id = :userId AND w.archived = true")
+    Optional<Worker> findArchivedByCompanyIdAndUserId(@Param("companyId") Long companyId, @Param("userId") Long userId);
+
     long countByCompanyIdAndArchivedFalse(Long companyId);
 }

--- a/src/main/java/com/workflow/service/email/EmailService.java
+++ b/src/main/java/com/workflow/service/email/EmailService.java
@@ -142,6 +142,34 @@ public class EmailService {
     }
 
     @Async
+    public void sendWorkerReactivationEmail(String toEmail, String companyName) {
+        try {
+            log.info("Sending worker reactivation email to: {} for company: {}", toEmail, companyName);
+
+            MimeMessage message = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
+
+            helper.setFrom(String.format("%s <%s>", fromName, fromEmail));
+            helper.setTo(toEmail);
+            helper.setSubject("You've been re-added to " + companyName);
+
+            String loginUrl = frontendUrl + "/login";
+            Context context = new Context();
+            context.setVariable("companyName", companyName);
+            context.setVariable("loginUrl", loginUrl);
+
+            String htmlContent = templateEngine.process("email/worker-reactivation", context);
+            helper.setText(htmlContent, true);
+
+            mailSender.send(message);
+            log.info("Worker reactivation email sent successfully to: {}", toEmail);
+
+        } catch (MessagingException e) {
+            log.error("Failed to send worker reactivation email to: {}", toEmail, e);
+        }
+    }
+
+    @Async
     public void sendMemberReactivationEmail(String toEmail, String companyName, CompanyRole companyRole) {
         try {
             log.info("Sending member reactivation email to: {} for company: {}", toEmail, companyName);

--- a/src/main/java/com/workflow/service/worker/WorkerInvitationService.java
+++ b/src/main/java/com/workflow/service/worker/WorkerInvitationService.java
@@ -56,9 +56,29 @@ public class WorkerInvitationService {
         seatLimitService.assertCapacity(company.getId());
 
         // Check if email already registered in User table
-        if (userRepository.findByEmail(email).isPresent()) {
-            log.warn("Attempted to invite already registered email: {}", email);
-            throw new UserAlreadyExistsException("Email already registered");
+        User existingUser = userRepository.findByEmail(email).orElse(null);
+        if (existingUser != null) {
+            // The User row survives worker removal (deleteWorker only archives the Worker),
+            // so re-adding a previously removed worker at this same company should reactivate
+            // their existing account instead of blocking on "already exists". If no archived
+            // Worker for THIS company matches, the email belongs to an unrelated account —
+            // keep blocking that case.
+            Worker archivedWorker = workerRepository
+                    .findArchivedByCompanyIdAndUserId(company.getId(), existingUser.getId())
+                    .orElseThrow(() -> {
+                        log.warn("Attempted to invite already registered email: {}", email);
+                        return new UserAlreadyExistsException("Email already registered");
+                    });
+
+            archivedWorker.setArchived(false);
+            workerRepository.save(archivedWorker);
+
+            emailService.sendWorkerReactivationEmail(email, company.getName());
+
+            log.info("Worker reactivated: workerId={}, userId={}, company={}",
+                    archivedWorker.getId(), existingUser.getId(), company.getName());
+
+            return new WorkerInviteResponse(email, "Worker reactivated successfully", null);
         }
 
         // Check if worker with this email already exists

--- a/src/main/resources/templates/email/worker-reactivation.html
+++ b/src/main/resources/templates/email/worker-reactivation.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Re-added to Team - Workfloow App</title>
+</head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.6; color: #333333; margin: 0; padding: 0; background-color: #f5f5f5;">
+    <div style="max-width: 600px; margin: 20px auto; padding: 0 20px;">
+        <div style="background-color: #ffffff; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.1);">
+
+            <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); background-color: #6f72c5; padding: 40px 30px; text-align: center;">
+                <h1 style="margin: 0; font-size: 28px; font-weight: 600; letter-spacing: 0.5px; color: #ffffff; font-family: Arial, Helvetica, sans-serif;">Workfloow App</h1>
+            </div>
+
+            <div style="padding: 40px 30px;">
+                <h2 style="color: #333333 !important; font-size: 24px; margin: 0 0 20px 0; font-weight: 600; font-family: Arial, Helvetica, sans-serif;">You've Been Re-added to the Team!</h2>
+                <p style="margin: 15px 0; color: #555555; font-size: 15px;">You've been re-added as a worker at <span th:text="${companyName}" style="display: inline-block; padding: 6px 14px; background-color: #f3f4f6; color: #667eea; border-radius: 6px; font-weight: 600; font-size: 14px;">Company Name</span>.</p>
+                <p style="margin: 15px 0; color: #555555; font-size: 15px;">Log in to continue. If you've forgotten your password, use the password reset option on the login page.</p>
+
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin: 35px 0;">
+                    <tr>
+                        <td align="center">
+                            <a th:href="${loginUrl}" style="display: inline-block; padding: 16px 40px; background-color: #667eea; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: #ffffff; text-decoration: none; border-radius: 8px; font-weight: 600; font-size: 16px; font-family: Arial, Helvetica, sans-serif;">Log In</a>
+                        </td>
+                    </tr>
+                </table>
+
+                <p style="color: #888888; font-size: 13px; text-align: center;">
+                    Or copy and paste this link into your browser:<br>
+                    <span th:text="${loginUrl}" style="word-break: break-all; display: inline-block; margin-top: 8px;">login-link</span>
+                </p>
+
+                <p style="margin-top: 30px; color: #666666; font-size: 14px;">
+                    If you weren't expecting this or have any questions, please contact the company administrator.
+                </p>
+            </div>
+
+            <table cellpadding="0" cellspacing="0" border="0" width="100%" style="background-color: #f8f9fa; border-top: 1px solid #e9ecef;">
+                <tr>
+                    <td align="center" style="padding: 25px 30px;">
+                        <p style="margin: 5px 0; font-size: 13px; color: #6c757d; font-family: Arial, Helvetica, sans-serif;">This is an automated message, please do not reply to this email.</p>
+                        <p style="margin: 5px 0; font-size: 13px; color: #6c757d; font-family: Arial, Helvetica, sans-serif;">&copy; 2026 <a href="https://www.workfloow.app/" style="color: #667eea; text-decoration: underline; font-weight: 600;">Workfloow App</a>. All rights reserved.</p>
+                        <table cellpadding="0" cellspacing="0" border="0" align="center" style="margin-top: 14px;">
+                            <tr>
+                                <td>
+                                    <a href="https://www.linkedin.com/company/workfloowapp/" target="_blank" style="display: inline-block; background-color: #0a66c2; color: #ffffff; text-decoration: none; border-radius: 5px; padding: 5px 10px; font-family: Arial, Helvetica, sans-serif; font-size: 13px; font-weight: 700; letter-spacing: 0.5px;">in LinkedIn</a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+            </table>
+
+        </div>
+    </div>
+</body>
+</html>

--- a/src/test/java/com/workflow/service/worker/WorkerInvitationServiceTest.java
+++ b/src/test/java/com/workflow/service/worker/WorkerInvitationServiceTest.java
@@ -210,11 +210,13 @@ class WorkerInvitationServiceTest {
     }
 
     @Test
-    @DisplayName("Should throw exception when email already registered")
+    @DisplayName("Should throw exception when email belongs to an unrelated account (no archived worker at this company)")
     void createInvitation_EmailAlreadyRegistered() {
         // Arrange
         when(companyService.findCompanyByUserId(companyUser.getId())).thenReturn(testCompany);
         when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(workerUser));
+        when(workerRepository.findArchivedByCompanyIdAndUserId(testCompany.getId(), workerUser.getId()))
+                .thenReturn(Optional.empty());
 
         // Act & Assert
         UserAlreadyExistsException exception = assertThrows(
@@ -223,6 +225,35 @@ class WorkerInvitationServiceTest {
         );
 
         assertEquals("Email already registered", exception.getMessage());
+        verify(invitationRepository, never()).save(any());
+        verify(emailService, never()).sendWorkerInvitationEmail(anyString(), anyString(), anyString());
+        verify(emailService, never()).sendWorkerReactivationEmail(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("Should reactivate an archived worker at this company instead of blocking")
+    void createInvitation_ReactivatesArchivedWorker() {
+        // Arrange
+        testWorker.setArchived(true);
+        when(companyService.findCompanyByUserId(companyUser.getId())).thenReturn(testCompany);
+        when(userRepository.findByEmail(TEST_EMAIL)).thenReturn(Optional.of(workerUser));
+        when(workerRepository.findArchivedByCompanyIdAndUserId(testCompany.getId(), workerUser.getId()))
+                .thenReturn(Optional.of(testWorker));
+        when(workerRepository.save(any(Worker.class))).thenAnswer(i -> i.getArguments()[0]);
+        doNothing().when(emailService).sendWorkerReactivationEmail(anyString(), anyString());
+
+        // Act
+        WorkerInviteResponse response = workerInvitationService.createInvitation(TEST_EMAIL, companyUser.getId());
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(TEST_EMAIL, response.email());
+        assertEquals("Worker reactivated successfully", response.message());
+        assertNull(response.expiresAt());
+        assertFalse(testWorker.isArchived());
+
+        verify(workerRepository).save(testWorker);
+        verify(emailService).sendWorkerReactivationEmail(TEST_EMAIL, testCompany.getName());
         verify(invitationRepository, never()).save(any());
         verify(emailService, never()).sendWorkerInvitationEmail(anyString(), anyString(), anyString());
     }


### PR DESCRIPTION
deleteWorker only archives the Worker row, the underlying User account survives, so re-inviting a previously removed worker's email always hit "already exists". Mirror the existing company-member reactivation fix: on invite, check for an archived Worker at this company for that email and reactivate it instead of throwing, only blocking when the email genuinely belongs to an unrelated account.