### PR TITLE
fix(invoice): stop generateInvoice failing 500 after every commit

### DIFF
--- a/src/main/java/com/workflow/repository/financial/EstimateRepository.java
+++ b/src/main/java/com/workflow/repository/financial/EstimateRepository.java
@@ -24,8 +24,13 @@ public interface EstimateRepository extends JpaRepository<Estimate, Long> {
            "WHERE e.id = :id AND e.company.id = :companyId")
     Optional<Estimate> findByIdAndCompanyId(@Param("id") Long id, @Param("companyId") Long companyId);
 
+    // Bank details eagerly fetched for InvoiceService's PDF rendering, which runs after the
+    // write transaction has already committed (see InvoiceService.generateInvoice) — without
+    // this, an untouched lazy Company.bankDetails proxy throws LazyInitializationException for
+    // any company that actually has bank details configured.
     @Query("SELECT e FROM Estimate e " +
-           "JOIN FETCH e.company " +
+           "JOIN FETCH e.company c " +
+           "LEFT JOIN FETCH c.bankDetails " +
            "JOIN FETCH e.job j " +
            "LEFT JOIN FETCH j.customer " +
            "LEFT JOIN FETCH e.lineItems " +

--- a/src/main/java/com/workflow/repository/financial/InvoiceRepository.java
+++ b/src/main/java/com/workflow/repository/financial/InvoiceRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -51,9 +52,14 @@ public interface InvoiceRepository extends JpaRepository<Invoice, Long> {
     @Query("DELETE FROM Invoice i WHERE i.estimate.job.id = :jobId")
     void deleteByJobId(@Param("jobId") Long jobId);
 
-    // Invoice rows are saved before the PDF exists (PDF generation happens afterCommit),
-    // so the size can't be set on the entity being saved like every other upload site — it's
-    // written back once the byte count is actually known, right after the S3 upload succeeds.
+    // Invoice rows are saved before the PDF exists, so the size can't be set on the entity being
+    // saved like every other upload site — it's written back once the byte count is actually
+    // known, right after the S3 upload succeeds, well after the save transaction has committed.
+    // Explicit @Transactional is required here (unlike SimpleJpaRepository's built-in save/delete,
+    // custom @Modifying query methods get no transaction of their own from Spring Data JPA — they
+    // only work by joining an already-active one), since this is called with no ambient
+    // transaction from InvoiceService.generateInvoice.
+    @Transactional
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Invoice i SET i.fileSizeBytes = :fileSizeBytes WHERE i.id = :id")
     void updateFileSizeBytes(@Param("id") Long id, @Param("fileSizeBytes") long fileSizeBytes);

--- a/src/main/java/com/workflow/service/invoice/InvoiceService.java
+++ b/src/main/java/com/workflow/service/invoice/InvoiceService.java
@@ -28,8 +28,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.io.ByteArrayInputStream;
 import java.math.BigDecimal;
@@ -42,7 +41,6 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class InvoiceService implements IInvoiceService {
 
@@ -53,13 +51,14 @@ public class InvoiceService implements IInvoiceService {
     private final IStorageQuotaService storageQuotaService;
     private final InvoicePdfRenderer pdfRenderer;
     private final CompanyCounterService companyCounterService;
+    private final TransactionTemplate transactionTemplate;
 
     @Override
     public InvoiceResponse generateInvoice(Long estimateId, InvoiceCreateRequest request, Long companyId) {
-        // Must run BEFORE the invoice row is created below, not after this transaction commits.
-        // PDF generation (and therefore the real byte count) is deliberately deferred to the
-        // afterCommit callback to avoid holding DB locks during slow CPU/S3 work, so the exact
-        // size isn't knowable yet here — this pre-check uses incomingBytes=0, i.e. "is the
+        // Must run BEFORE the invoice row is created below, not after the write transaction
+        // commits. PDF generation (and therefore the real byte count) deliberately happens after
+        // that transaction commits, to avoid holding DB locks during slow CPU/S3 work, so the
+        // exact size isn't knowable yet here — this pre-check uses incomingBytes=0, i.e. "is the
         // company already over its cap at all," which is enough to stop the bug this was fixing:
         // an over-quota company getting a 409/402 implying nothing happened while an Invoice row
         // (with a consumed, audit-significant invoice-number sequence) is left durably committed.
@@ -131,56 +130,44 @@ public class InvoiceService implements IInvoiceService {
         String invoiceNumber = String.format("INV-%d-%05d", LocalDate.now().getYear(), invoiceSeq);
         String s3Key = String.format("invoices/%d/%s.pdf", companyId, invoiceNumber);
 
-        Invoice invoiceToSave = Invoice.builder()
-                .estimate(estimate)
-                .company(estimate.getCompany())
-                .invoiceNumber(invoiceNumber)
-                .s3Key(s3Key)
-                .lineItemSnapshots(snapshots)
-                .dueDate(request.getDueDate())
-                .reference(request.getReference())
-                .totalNet(totalNet)
-                .totalVat(totalVat)
-                .grandTotal(grandTotal)
-                .build();
-
-        snapshots.forEach(s -> s.setInvoice(invoiceToSave));
-        Invoice invoice = invoiceRepository.save(invoiceToSave);
-
         List<Long> selectedIds = selectedItems.stream().map(EstimateLineItem::getId).toList();
-        estimateLineItemRepository.markAsInvoiced(selectedIds);
 
-        // PDF generation and upload after TX commits — X locks on invoices and
-        // job_line_item_snapshots released before CPU/S3 work.
-        final Invoice committedInvoice = invoice;
-        final List<EstimateLineItem> itemsForPdf = selectedItems;
-        final Estimate estimateForPdf = estimate;
-        if (TransactionSynchronizationManager.isSynchronizationActive()) {
-            log.debug("[Invoice] Registering PDF+S3 upload for afterCommit key={}", s3Key);
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    try {
-                        log.debug("[Invoice] afterCommit: generating PDF key={}", s3Key);
-                        byte[] pdfBytes = generatePdf(committedInvoice, invoiceNumber, itemsForPdf, estimateForPdf);
-                        log.debug("[Invoice] afterCommit: uploading to S3 key={}", s3Key);
-                        storageService.upload(s3Key, new ByteArrayInputStream(pdfBytes), pdfBytes.length, "application/pdf");
-                        invoiceRepository.updateFileSizeBytes(committedInvoice.getId(), pdfBytes.length);
-                        storageQuotaService.recordUpload(companyId, pdfBytes.length);
-                        log.info("[Invoice] S3 upload complete key={}", s3Key);
-                    } catch (Exception e) {
-                        log.error("[Invoice] PDF/S3 failed key={}", s3Key, e);
-                        throw e;
-                    }
-                }
-            });
-        } else {
-            log.warn("[Invoice] No active TX sync — generating PDF and uploading S3 inline key={}", s3Key);
-            byte[] pdfBytes = generatePdf(invoice, invoiceNumber, selectedItems, estimate);
-            storageService.upload(s3Key, new ByteArrayInputStream(pdfBytes), pdfBytes.length, "application/pdf");
-            invoiceRepository.updateFileSizeBytes(invoice.getId(), pdfBytes.length);
-            storageQuotaService.recordUpload(companyId, pdfBytes.length);
-        }
+        // Short write transaction — commits and releases X locks on invoices and
+        // job_line_item_snapshots before the slow CPU/S3 work below runs. Deliberately NOT
+        // TransactionSynchronizationManager.afterCommit(): a callback registered there runs after
+        // the transaction has already committed, so any @Modifying repository call inside it
+        // (updateFileSizeBytes, recordUpload) fails with "Executing an update/delete query"
+        // (Hibernate has no active transaction at that point) — every single time, not
+        // intermittently. TransactionTemplate.execute() instead returns only once its own
+        // self-contained transaction has fully committed, so the code after it is genuinely
+        // outside any transaction and free to make its own separately-transactional calls.
+        Invoice invoice = transactionTemplate.execute(status -> {
+            Invoice invoiceToSave = Invoice.builder()
+                    .estimate(estimate)
+                    .company(estimate.getCompany())
+                    .invoiceNumber(invoiceNumber)
+                    .s3Key(s3Key)
+                    .lineItemSnapshots(snapshots)
+                    .dueDate(request.getDueDate())
+                    .reference(request.getReference())
+                    .totalNet(totalNet)
+                    .totalVat(totalVat)
+                    .grandTotal(grandTotal)
+                    .build();
+
+            snapshots.forEach(s -> s.setInvoice(invoiceToSave));
+            Invoice saved = invoiceRepository.save(invoiceToSave);
+            estimateLineItemRepository.markAsInvoiced(selectedIds);
+            return saved;
+        });
+
+        log.debug("[Invoice] Generating PDF key={}", s3Key);
+        byte[] pdfBytes = generatePdf(invoice, invoiceNumber, selectedItems, estimate);
+        log.debug("[Invoice] Uploading to S3 key={}", s3Key);
+        storageService.upload(s3Key, new ByteArrayInputStream(pdfBytes), pdfBytes.length, "application/pdf");
+        invoiceRepository.updateFileSizeBytes(invoice.getId(), pdfBytes.length);
+        storageQuotaService.recordUpload(companyId, pdfBytes.length);
+        log.info("[Invoice] S3 upload complete key={}", s3Key);
 
         String presignedUrl = storageService.generatePresignedUrl(s3Key);
         return InvoiceResponse.fromEntity(invoice, presignedUrl);


### PR DESCRIPTION
Two writes in the PDF/S3 bookkeeping step ran with no active transaction, so they always threw once the invoice row genuinely committed (invisible in @Transactional tests, which never commit for real):

- PDF generation, S3 upload, and file-size bookkeeping were deferred into a TransactionSynchronizationManager.afterCommit() callback, which by definition runs after the transaction has already closed. Replaced with a short TransactionTemplate-wrapped write (invoice save + markAsInvoiced), mirroring EstimateDocumentService's already -working pattern, so the PDF/S3/bookkeeping work runs as ordinary post-commit code free to open its own transactions as needed.

- InvoiceRepository.updateFileSizeBytes is a raw @Modifying query with no @Transactional of its own, unlike StorageQuotaService .recordUpload which has one — Spring Data JPA does not auto-wrap custom modifying queries in their own transaction, they only work by joining an already-active one. Added @Transactional directly to the repository method.

Also fetches Company.bankDetails eagerly in the estimate query PDF generation depends on — a second latent LazyInitializationException for any company with real bank details configured, now that PDF generation runs after the transaction closes instead of inside it.

Verified end-to-end against a real (non-rolled-back) transaction: correct 201, real PDF/S3 upload, file_size_bytes and storage_used_bytes both correctly bookkept.